### PR TITLE
Month Selector Bug

### DIFF
--- a/src/components/calendar/calendar.css
+++ b/src/components/calendar/calendar.css
@@ -149,10 +149,15 @@
 .tail-datetime-calendar .calendar-date table tbody tr > *.today:after {
   border-color: #3296c8;
 }
-.tail-datetime-calendar .calendar-date table tbody tr > *:hover {
+.tail-datetime-calendar .calendar-date table tbody tr > td.calendar-day:hover {
   color: #cd283c;
 }
-.tail-datetime-calendar .calendar-date table tbody tr > *:hover:after {
+.tail-datetime-calendar
+  .calendar-date
+  table
+  tbody
+  tr
+  > td.calendar-day:hover:after {
   border-color: #cd283c;
 }
 .tail-datetime-calendar .calendar-date table tbody tr > *.empty,

--- a/src/components/calendar/calendar.css
+++ b/src/components/calendar/calendar.css
@@ -152,12 +152,7 @@
 .tail-datetime-calendar .calendar-date table tbody tr > td.calendar-day:hover {
   color: #cd283c;
 }
-.tail-datetime-calendar
-  .calendar-date
-  table
-  tbody
-  tr
-  > td.calendar-day:hover:after {
+.tail-datetime-calendar .calendar-date table tbody tr > td.calendar-day:hover:after {
   border-color: #cd283c;
 }
 .tail-datetime-calendar .calendar-date table tbody tr > *.empty,

--- a/src/components/calendar/index.js
+++ b/src/components/calendar/index.js
@@ -187,7 +187,7 @@ export default class Calendar extends React.Component {
       <table className="calendar-month">
         <thead>
           <tr>
-            <th colSpan="4">Select a Yeah</th>
+            <th colSpan="4">Select a Year</th>
           </tr>
         </thead>
         <tbody>{yearlist}</tbody>
@@ -257,14 +257,14 @@ export default class Calendar extends React.Component {
             onClick={e => {
               this.onPrev();
             }}
-            class="calendar-button button-prev"
+            className="calendar-button button-prev"
           />
           {!this.state.showMonthTable && !this.state.showYearEditor && (
             <span
               onClick={e => {
                 this.showMonth();
               }}
-              class="calendar-label"
+              className="calendar-label"
             >
               {this.month()},
             </span>


### PR DESCRIPTION
There is an issue with CSS hover selectors in the Month Selector. Because the rule is too vague the month selector inherits the hover class from the calendar days.

For visual reference:
![Screen Shot 2022-03-08 at 5 10 40 PM](https://user-images.githubusercontent.com/1222666/157321598-b7f1a73e-5c62-4d1a-8ea6-ed452a7423c4.png)

Fixed version:
![Screen Shot 2022-03-08 at 5 09 28 PM](https://user-images.githubusercontent.com/1222666/157321622-2a060ac0-9988-49af-ac24-06d1371d804d.png)
